### PR TITLE
Reset parameters explicitly when object is constructed to remove copied data.

### DIFF
--- a/example/config/param_file_to_inject.yaml
+++ b/example/config/param_file_to_inject.yaml
@@ -1,0 +1,3 @@
+the_answer_to_everything_was_caculated_by: Deep Thought
+earth_was_build_by: Magratheans
+

--- a/example/config/parameters_injection.yaml
+++ b/example/config/parameters_injection.yaml
@@ -1,0 +1,5 @@
+the_answer_to_life: 42
+
+
+the_question_to_life: What do you get if you multiply six by nine?
+param_file_to_inject: config/param_file_to_inject.yaml

--- a/example/parameter_injection_example.launch.py
+++ b/example/parameter_injection_example.launch.py
@@ -1,0 +1,51 @@
+# $LICENSE$
+
+from launch import LaunchDescription
+from launch.actions import DeclareLaunchArgument, ExecuteProcess, OpaqueFunction
+from launch.substitutions import LaunchConfiguration
+from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
+
+from launch_param_builder import ParameterBuilder
+from launch_param_builder.utils import get_path
+
+
+def launch_setup(context, *args, **kwargs):
+
+    # Initialize Arguments
+    injection_params_package = LaunchConfiguration("injection_params_package").perform(context)
+
+    base_params = (
+        ParameterBuilder(injection_params_package)
+        .yaml(file_path="config/parameters_injection.yaml")
+        .to_dict()
+    )
+
+    print("Base Params File Content: ")
+    print(base_params)
+
+    print(
+        "File path to inject: " +
+        base_params["param_file_to_inject"])
+    params_to_inject = ParameterBuilder(injection_params_package).yaml(base_params["param_file_to_inject"]).to_dict()
+    print("Params to inject: ")
+    print(params_to_inject)
+
+    base_params.update(params_to_inject)
+    print("Update parameters: ")
+    print(base_params)
+
+    return []
+
+
+def generate_launch_description():
+    # Declare arguments
+    declared_arguments = [
+        DeclareLaunchArgument(
+            "injection_params_package",
+            default_value="launch_param_builder",
+            description="Package with example files to demonstrate parameters injection.",
+        ),
+    ]
+
+    return LaunchDescription(declared_arguments + [OpaqueFunction(function=launch_setup)])

--- a/launch_param_builder/launch_param_builder.py
+++ b/launch_param_builder/launch_param_builder.py
@@ -40,6 +40,7 @@ class ParameterBuilder(object):
 
     def __init__(self, package_name: str):
         self._package_path = Path(get_package_share_directory(package_name))
+        self._parameters = {}
 
     def yaml(self, file_path: str, parameter_namespace: str = None):
         if parameter_namespace:

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,10 @@ setup(
         ("share/ament_index/resource_index/packages", ["resource/" + package_name]),
         (
             "share/" + package_name + "/launch",
-            ["example/launch_param_builder_example.launch.py"],
+            [
+                "example/launch_param_builder_example.launch.py",
+                "example/parameter_injection_example.launch.py",
+            ],
         ),
         ("share/" + package_name + "/config", glob("example/config/*")),
         ("share/" + package_name, ["package.xml"]),


### PR DESCRIPTION
There is an issue I stumbled upon that the data in the internal dictionary are duplicated when rosparam builder is used multiple times in a launch file.

You can simply test this by commenting out the explicit reset in the constructor and checking the output of newly created launch files.
